### PR TITLE
common: Fix ambiguous CHAR_MIN/MAX definition

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -42,8 +42,8 @@ const char *defaultOutFnC( const char *inputFileName )
 
 HostType hostTypesC[] =
 {
-	{ "char",      0,      "char",    true,   true,  false,  CHAR_MIN,  CHAR_MAX,   0, 0,          sizeof(char) },
-	{ "signed",   "char",  "char",    true,   true,  false,  CHAR_MIN,  CHAR_MAX,   0, 0,          sizeof(char) },
+	{ "char",      0,      "char",    true,   true,  false,  SCHAR_MIN, SCHAR_MAX,  0, 0,          sizeof(char) },
+	{ "signed",   "char",  "char",    true,   true,  false,  SCHAR_MIN, SCHAR_MAX,  0, 0,          sizeof(char) },
 	{ "unsigned", "char",  "uchar",   false,  true,  false,  0, 0,                  0, UCHAR_MAX,  sizeof(unsigned char) },
 	{ "short",     0,      "short",   true,   true,  false,  SHRT_MIN,  SHRT_MAX,   0, 0,          sizeof(short) },
 	{ "signed",   "short", "short",   true,   true,  false,  SHRT_MIN,  SHRT_MAX,   0, 0,          sizeof(short) },

--- a/src/host-csharp/main.cc
+++ b/src/host-csharp/main.cc
@@ -40,7 +40,7 @@ const char *defaultOutFnCSharp( const char *inputFileName )
 
 HostType hostTypesCSharp[] =
 {
-	{ "sbyte",   0,  "sbyte",   true,   true,  false,  CHAR_MIN,  CHAR_MAX,    0, 0,           1 },
+	{ "sbyte",   0,  "sbyte",   true,   true,  false,  SCHAR_MIN, SCHAR_MAX,   0, 0,           1 },
 	{ "byte",    0,  "byte",    false,  true,  false,  0, 0,                   0, UCHAR_MAX,   1 },
 	{ "short",   0,  "short",   true,   true,  false,  SHRT_MIN,  SHRT_MAX,    0, 0,           2 },
 	{ "ushort",  0,  "ushort",  false,  true,  false,  0, 0,                   0, USHRT_MAX,   2 },

--- a/src/host-d/main.cc
+++ b/src/host-d/main.cc
@@ -40,7 +40,7 @@ const char *defaultOutFnD( const char *inputFileName )
 
 HostType hostTypesD[] =
 {
-	{ "byte",    0,  "byte",    true,   true,  false,  CHAR_MIN,  CHAR_MAX,    0, 0,           1 },
+	{ "byte",    0,  "byte",    true,   true,  false,  SCHAR_MIN, SCHAR_MAX,   0, 0,           1 },
 	{ "ubyte",   0,  "ubyte",   false,  true,  false,  0, 0,                   0, UCHAR_MAX,   1 },
 	{ "char",    0,  "char",    false,  true,  false,  0, 0,                   0, UCHAR_MAX,   1 },
 	{ "short",   0,  "short",   true,   true,  false,  SHRT_MIN,  SHRT_MAX,    0, 0,           2 },

--- a/src/host-java/main.cc
+++ b/src/host-java/main.cc
@@ -36,7 +36,7 @@ const char *defaultOutFnJava( const char *inputFileName )
 
 HostType hostTypesJava[] = 
 {
-	{ "byte",    0,  "byte",   true,   true,  false,  CHAR_MIN,  CHAR_MAX,    0, 0,           1 },
+	{ "byte",    0,  "byte",   true,   true,  false,  SCHAR_MIN, SCHAR_MAX,   0, 0,           1 },
 	{ "short",   0,  "short",  true,   true,  false,  SHRT_MIN,  SHRT_MAX,    0, 0,           2 },
 	{ "char",    0,  "char",   false,  true,  false,  0, 0,                   0, USHRT_MAX,   2 },
 	{ "int",     0,  "int",    true,   true,  false,  INT_MIN,   INT_MAX,     0, 0,           4 },

--- a/src/host-js/main.cc
+++ b/src/host-js/main.cc
@@ -36,7 +36,7 @@ const char *defaultOutFnJs( const char *inputFileName )
 
 HostType hostTypesJS[] =
 {
-	{ "s8",     0, "int8",    true,   true,  false,  CHAR_MIN,  CHAR_MAX,   0, 0,          1 },
+	{ "s8",     0, "int8",    true,   true,  false,  SCHAR_MIN, SCHAR_MAX,  0, 0,          1 },
 	{ "u8",     0, "uint8",   false,  true,  false,  0, 0,                  0, UCHAR_MAX,  1 },
 	{ "s16",    0, "int16",   true,   true,  false,  SHRT_MIN,  SHRT_MAX,   0, 0,          2 },
 	{ "u16",    0, "uint16",  false,  true,  false,  0, 0,                  0, USHRT_MAX,  2 },

--- a/src/host-ruby/main.cc
+++ b/src/host-ruby/main.cc
@@ -28,7 +28,7 @@ extern struct colm_sections rlhcRuby;
 /* What are the appropriate types for ruby? */
 static HostType hostTypesRuby[] = 
 {
-	{ "char",    0,  "char",   true,   true,  false,  CHAR_MIN,  CHAR_MAX,    0, 0, 1 },
+	{ "char",    0,  "char",   true,   true,  false,  SCHAR_MIN, SCHAR_MAX,   0, 0, 1 },
 	{ "int",     0,  "int",    true,   true,  false,  INT_MIN,   INT_MAX,     0, 0, 4 },
 };
 


### PR DESCRIPTION
According to C/C++ standards, char is implementation-defined whether
it could hold negative values.
See: http://www.cplusplus.com/reference/climits/
In ragel char is treated as a signed value with range as [-128, 127].
This means that the CHAR_MIN/CHAR_MAX should be replaced with a more
accurate definition to align across different systems and library implementations.

Change-Id: I10668f2d2550b603101dc68f4cc1121035022abd
Signed-off-by: Jun He <jun.he@linaro.org>