### PR TITLE
Fix build without .la files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,16 +44,24 @@ AC_ARG_WITH(colm,
 	[
 		COLM="$withval/bin/colm"
 		COLM_WRAP="$withval/bin/colm-wrap"
-		CPPFLAGS="-I$withval/include ${CPPFLAGS}"
 		CPPFLAGS="-I$withval/include/aapl ${CPPFLAGS}"
-		LDFLAGS="-L$withval/lib ${LDFLAGS}"
-		LIBCOLM_LA="$withval/lib/libcolm.la"
-		LIBFSM_LA="$withval/lib/libfsm.la"
 		COLM_SHARE="$withval/share/colm"
 	],
 	[]
 )
 
+AC_CHECK_LIB(
+	[colm],
+	[colm_run_program],
+	[LIBCOLM_LA=-lcolm],
+	[AC_ERROR([libcolm is required to build ragel])]
+)
+AC_CHECK_LIB(
+	[fsm],
+	[hostLangAsm],
+	[LIBFSM_LA=-lfsm],
+	[AC_ERROR([libfsm is required to build ragel])]
+)
 AC_CHECK_FILES(
 	[$COLM],
 	[],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,7 +40,6 @@ nodist_ragel_SOURCES = \
 	parse.c rlreduce.cc
 
 ragel_LDADD = $(LIBFSM_LA) $(LIBCOLM_LA) libragel.la
-ragel_DEPENDENCIES = $(LIBFSM_LA) $(LIBCOLM_LA) libragel.la
 
 BUILT_SOURCES = \
 	version.h \


### PR DESCRIPTION
Note: I tested this against `7.0.4`.

Many distros do no ship `.la` files which breaks the build and additionally when using slibtool instead of GNU libtool the `.la` files are not installed by default.

This fixes the build to use the linker flags `-lcolm` and `-lfsm` instead.

I also removed the some pointless variables.