### PR TITLE
Atoi example for Rust

### DIFF
--- a/examples/rust/Makefile
+++ b/examples/rust/Makefile
@@ -13,7 +13,6 @@ else
     .INTERMEDIATE: %.rs
 endif
 
-$(info [BUILD] Intermediate $(.INTERMEDIATE))
 $(info [BUILD] Executables: $(EXECUTABLES))
 
 all: $(EXECUTABLES)

--- a/examples/rust/Makefile
+++ b/examples/rust/Makefile
@@ -1,0 +1,34 @@
+RAGEL_RUST = ragel-rust
+RUSTC = rustc
+RUST_RAGEL_SOURCES = $(wildcard *.rs.rl)
+EXECUTABLES = $(RUST_RAGEL_SOURCES:.rs.rl=_rust)
+INTERMEDIATES = $(RUST_RAGEL_SOURCES:.rs.rl=.rs)
+KEEP_INTERMEDIATES ?= 0
+
+ifneq ($(KEEP_INTERMEDIATES),0)
+    $(info [BUILD] Keeping intermediate sources)
+    .PRECIOUS: %.rs
+else
+    $(info [BUILD] Not keeping intermediate sources)
+    .INTERMEDIATE: %.rs
+endif
+
+$(info [BUILD] Intermediate $(.INTERMEDIATE))
+$(info [BUILD] Executables: $(EXECUTABLES))
+
+all: $(EXECUTABLES)
+
+clean:
+	@echo [CLEAN]
+	find . -name '*.o' | xargs -n 1 rm -f
+	find . -name '*.ri' | xargs -n 1 rm -f
+	rm -f $(EXECUTABLES)
+	rm -f $(INTERMEDIATES)
+
+%_rust: %.rs
+	@echo [RUSTC] $@
+	@$(RUSTC) $< -o $@
+
+%.rs: %.rs.rl
+	@echo [RAGEL] $@
+	@$(RAGEL_RUST) $< -o $*.rs

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,6 +1,6 @@
 # Ragel source examples for Rust
 
-This directory contains examples of building Rust compilers with Ragel.
+This directory contains examples of building Rust parsers with Ragel.
 
 # Contibution
 

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -2,7 +2,7 @@
 
 This directory contains examples of building Rust compilers with Ragel.
 
-#Contibution
+# Contibution
 
 Please consider the following build system-related constraints when adding
 examples of your own, to seamlessly integrate your examples into build process.

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,0 +1,11 @@
+# Ragel source examples for Rust
+
+This directory contains examples of building Rust compilers with Ragel.
+
+#Contibution
+
+Please consider the following build system-related constraints when adding
+examples of your own, to seamlessly integrate your examples into build process.
+
+1. One file -- one example;
+2. Use `*.rs.rl` extension for your examples;

--- a/examples/rust/atoi.rs.rl
+++ b/examples/rust/atoi.rs.rl
@@ -1,0 +1,64 @@
+//
+// Convert a string to an integer.
+//
+
+%%{
+    machine atoi;
+    write data;
+}%%
+
+fn atoi(data: &[u8]) -> i32
+{
+    let mut cs: i32 = 0;
+    let mut p = 0usize;  // Start position
+    let mut pe = data.len();  // End position
+    let mut val = 0i32;  // Accumulated value
+    let mut neg = false;  // Negative number flag
+
+    %%{
+        action see_neg {
+            neg = true;
+        }
+
+        # Take a look at `fc`. It denotes current symbol
+        action add_digit {
+            val = val * 10 + (fc - ('0' as u8)) as i32;
+        }
+
+        main :=
+            ( '-'@see_neg | '+' )? ( digit @add_digit )+
+            '\n';
+
+        # Initialize and execute.
+        write init;
+        write exec;
+    }%%
+
+    if neg {
+        val = -val;
+    }
+
+    if cs < atoi_first_final {
+        println!("atoi: error");
+    }
+
+    return val;
+}
+
+
+const BUFSIZE: usize = 1024;
+
+fn main() {
+    use std::io::BufRead;
+    use std::convert::TryInto;
+
+    let stdin = std::io::stdin();
+    let mut handle = stdin.lock();
+
+    loop {
+        let mut buffer = String::new();
+        handle.read_line(&mut buffer);
+        let result = atoi(buffer.as_bytes());
+        println!("{}", result);
+    }
+}


### PR DESCRIPTION
Added Rust `atoi` example into `examples/` directory. Created an expandable build system to seamlessly add new examples.